### PR TITLE
add language parameter support for google and bing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ import suggests
 ['geese are evil', 'geese are mean', 'geese are aggressive', 'geese are jerks', 'geese are the worst', 'geese are scary', 'geese are dinosaurs', 'geese are protected', 'geese are annoying', 'geese are monogamous']
 ```
 
+Use the `hl` parameter to get suggestions in other languages:
+
+```python
+>>> s = suggests.get_suggests('los gansos son ', source='google', hl='es')
+2026-03-12 11:17:37,039 | 9860 | INFO | suggests | google | los gansos son
+>>> s['suggests']
+['los gansos son territoriales', 'los gansos son monogamos', 'los gansos son patos', 'los gansos son comestibles', 'los gansos son aves']
+```
+
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,22 @@ import suggests
 ['geese are evil', 'geese are mean', 'geese are aggressive', 'geese are jerks', 'geese are the worst', 'geese are scary', 'geese are dinosaurs', 'geese are protected', 'geese are annoying', 'geese are monogamous']
 ```
 
-Use the `hl` parameter to get suggestions in other languages:
+Use the `hl` parameter for Google (e.g. `'es'`, `'de'`, `'fr'`) to get suggestions in other languages:
 
 ```python
 >>> s = suggests.get_suggests('los gansos son ', source='google', hl='es')
-2026-03-12 11:17:37,039 | 9860 | INFO | suggests | google | los gansos son
+2026-03-12 11:40:41,677 | 26509 | INFO | suggests | google | los gansos son
 >>> s['suggests']
 ['los gansos son territoriales', 'los gansos son monogamos', 'los gansos son patos', 'los gansos son comestibles', 'los gansos son aves']
+```
+
+For Bing, use the `mkt` parameter (e.g. `'es-es'`, `'de-de'`, `'fr-fr'`) to get suggestions in other languages:
+
+```python
+>>> s = suggests.get_suggests('los gansos son ', source='bing', mkt='es-es')
+2026-03-12 11:40:43,764 | 26509 | INFO | suggests | bing | los gansos son
+>>> s['suggests']
+['los gansos son agresivos', 'que son los gansos', 'sonidos de gansos']
 ```
 
 

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -36,7 +36,11 @@ def prepare_qry(qry: str) -> str:
 
 def get_google_url(sclient: Optional[str] = "psy-ab", hl: Optional[str] = "en") -> str:
     """Get Google autocomplete API URL
-    
+
+    Args:
+        sclient (Optional[str]): Google search client identifier
+        hl (Optional[str]): Language code for results (e.g. 'en', 'de', 'fr')
+
     Returns:
         str: Base Google autocomplete API URL
     """
@@ -74,10 +78,12 @@ def requester(
         sesh (Optional[requests.Session]): Pass a custom requests session
         sleep (Optional[float]): Custom sleep duration
         allow_zip (bool): Enable response content unzipping
-    
+        sclient (Optional[str]): Google search client identifier
+        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+
     Returns:
         Optional[Union[dict, str]]: JSON response for Google, HTML string for Bing, None on error
-    
+
     Raises:
         AssertionError: If source is not 'bing' or 'google'
     """
@@ -116,7 +122,10 @@ def get_suggests(
         source (str): The search engine to submit the query to
         sesh (Optional[requests.Session]): Session for maintaining connection
         sleep (Optional[float]): Custom sleep duration
-    
+        sesh_headers (Optional[Dict[str, str]]): Custom session headers
+        sclient (Optional[str]): Google search client identifier
+        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+
     Returns:
         Dict[str, Any]: Dictionary containing query metadata and suggestions
     """
@@ -144,7 +153,9 @@ def get_suggests_tree(
     sesh: Optional[requests.Session] = None,
     sesh_headers: Optional[Dict[str, str]] = None,
     crawl_id: Optional[str] = None,
-    sleep: Optional[float] = None
+    sleep: Optional[float] = None,
+    sclient: Optional[str] = None,
+    hl: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """Retrieve autocomplete suggestions tree for a root query
     
@@ -156,7 +167,9 @@ def get_suggests_tree(
         sesh (Optional[requests.Session]): Session for maintaining connection
         crawl_id (Optional[str]): Unique identifier for the crawl session
         sleep (Optional[float]): Custom sleep duration
-    
+        sclient (Optional[str]): Google search client identifier
+        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+
     Returns:
         List[Dict[str, Any]]: List of suggestion trees with metadata
     """
@@ -165,7 +178,7 @@ def get_suggests_tree(
         sesh.headers.update(sesh_headers)
     
     depth = 0
-    root_branch = get_suggests(root, source, sesh, sleep)
+    root_branch = get_suggests(root, source, sesh, sleep, sclient=sclient, hl=hl)
     root_branch['depth'] = depth
     root_branch['root'] = root
     root_branch['crawl_id'] = crawl_id
@@ -186,7 +199,7 @@ def get_suggests_tree(
             if suggest_list:
                 for s in suggest_list:
                     if s not in all_suggests: # Don't crawl self-loops or duplicates
-                        branches = get_suggests(s, source, sesh, sleep)                    
+                        branches = get_suggests(s, source, sesh, sleep, sclient=sclient, hl=hl)
                         branches['depth'] = depth
                         branches['root'] = root
                         branches['crawl_id'] = crawl_id

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -16,19 +16,19 @@ log = logger.Logger().start()
 
 def sleep_random(x: float = 0.7, y: float = 1.4) -> None:
     """Sleep a random time with noise between x and y seconds
-    
+
     Args:
         x (float): Minimum sleep time in seconds
         y (float): Maximum sleep time in seconds
     """
     time.sleep(random.uniform(x,y))
-    
+
 def prepare_qry(qry: str) -> str:
     """Prepare query string for URL encoding
-    
+
     Args:
         qry (str): Raw query string
-    
+
     Returns:
         str: URL encoded query string
     """
@@ -38,7 +38,7 @@ def get_google_url(hl: str = "en", sclient: str = "psy-ab") -> str:
     """Get Google autocomplete API URL
 
     Args:
-        hl (str): Language code for results (e.g. 'en', 'de', 'fr')
+        hl (str): Language code (e.g. 'en', 'de', 'fr')
         sclient (str): Google search client identifier
 
     Returns:
@@ -47,16 +47,17 @@ def get_google_url(hl: str = "en", sclient: str = "psy-ab") -> str:
     params = urllib.parse.urlencode({'sclient': sclient, 'hl': hl, 'q': ''})
     return f'https://www.google.com/complete/search?{params}'
 
-def get_bing_url(cvid: str = 'CF23583902D944F1874B7D9E36F452CD') -> str:
+def get_bing_url(mkt: str = "en-us", cvid: str = 'CF23583902D944F1874B7D9E36F452CD') -> str:
     """Get Bing autocomplete API URL
 
     Args:
+        mkt (str): Market code (e.g. 'en-us', 'de-de', 'es-es')
         cvid (str): Bing API client ID
 
     Returns:
         str: Base Bing autocomplete API URL
     """
-    params = urllib.parse.urlencode({'mkt': 'en-us', 'cvid': cvid, 'q': ''})
+    params = urllib.parse.urlencode({'mkt': mkt, 'cvid': cvid, 'q': ''})
     return f'http://www.bing.com/AS/Suggestions?{params}'
 
 def requester(
@@ -65,7 +66,8 @@ def requester(
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
     allow_zip: bool = False,
-    hl: str = "en",
+    hl: Optional[str] = None,
+    mkt: Optional[str] = None,
     sclient: str = "psy-ab"
 ) -> Optional[Union[dict, str]]:
     """Requester with logging and specified user agent
@@ -76,7 +78,8 @@ def requester(
         sesh (Optional[requests.Session]): Pass a custom requests session
         sleep (Optional[float]): Custom sleep duration
         allow_zip (bool): Enable response content unzipping
-        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
+        mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
         sclient (str): Google search client identifier
 
     Returns:
@@ -89,7 +92,10 @@ def requester(
 
     sesh = sesh if sesh else requests.Session()
 
-    base = get_bing_url() if source == 'bing' else get_google_url(hl, sclient)
+    if source == 'bing':
+        base = get_bing_url(mkt or 'en-us')
+    else:
+        base = get_google_url(hl or 'en', sclient)
     url = base + prepare_qry(qry)
 
     time.sleep(sleep) if sleep else sleep_random()
@@ -110,7 +116,8 @@ def get_suggests(
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
     sesh_headers: Optional[Dict[str, str]] = None,
-    hl: str = "en",
+    hl: Optional[str] = None,
+    mkt: Optional[str] = None,
     sclient: str = "psy-ab"
 ) -> Dict[str, Any]:
     """Scrape and parse search engine suggestion data for a query.
@@ -121,7 +128,8 @@ def get_suggests(
         sesh (Optional[requests.Session]): Session for maintaining connection
         sleep (Optional[float]): Custom sleep duration
         sesh_headers (Optional[Dict[str, str]]): Custom session headers
-        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
+        mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
         sclient (str): Google search client identifier
 
     Returns:
@@ -130,14 +138,14 @@ def get_suggests(
     sesh = sesh if sesh else requests.Session()
     if sesh_headers:
         sesh.headers.update(sesh_headers)
-    
+
     tree: Dict[str, Any] = {
         'qry': qry,
         'datetime': str(datetime.now(timezone.utc).replace(tzinfo=None)),
         'source': source,
-        'data': requester(qry, source, sesh, sleep, hl=hl, sclient=sclient)
+        'data': requester(qry, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
     }
-    
+
     parser = parsing.parse_bing if source == 'bing' else parsing.parse_google
     parsed = parser(tree['data'], qry)
     tree.update(parsed)
@@ -152,7 +160,8 @@ def get_suggests_tree(
     sesh_headers: Optional[Dict[str, str]] = None,
     crawl_id: Optional[str] = None,
     sleep: Optional[float] = None,
-    hl: str = "en",
+    hl: Optional[str] = None,
+    mkt: Optional[str] = None,
     sclient: str = "psy-ab"
 ) -> List[Dict[str, Any]]:
     """Retrieve autocomplete suggestions tree for a root query
@@ -165,7 +174,8 @@ def get_suggests_tree(
         sesh (Optional[requests.Session]): Session for maintaining connection
         crawl_id (Optional[str]): Unique identifier for the crawl session
         sleep (Optional[float]): Custom sleep duration
-        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
+        mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
         sclient (str): Google search client identifier
 
     Returns:
@@ -174,9 +184,9 @@ def get_suggests_tree(
     sesh = sesh if sesh else requests.Session()
     if sesh_headers:
         sesh.headers.update(sesh_headers)
-    
+
     depth = 0
-    root_branch = get_suggests(root, source, sesh, sleep, hl=hl, sclient=sclient)
+    root_branch = get_suggests(root, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
     root_branch['depth'] = depth
     root_branch['root'] = root
     root_branch['crawl_id'] = crawl_id
@@ -192,20 +202,20 @@ def get_suggests_tree(
     while depth < max_depth:
         suggests = {d['qry']: d['suggests'] for d in tree if d['depth']==depth}
         depth += 1
-        
+
         for qry, suggest_list in suggests.items():
             if suggest_list:
                 for s in suggest_list:
                     if s not in all_suggests: # Don't crawl self-loops or duplicates
-                        branches = get_suggests(s, source, sesh, sleep, hl=hl, sclient=sclient)
+                        branches = get_suggests(s, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
                         branches['depth'] = depth
                         branches['root'] = root
                         branches['crawl_id'] = crawl_id
-                        if save_to: 
+                        if save_to:
                             outfile.write(f'{json.dumps(branches)}\n')
-                        tree.append(branches)            
+                        tree.append(branches)
                         all_suggests.add(s)
-                        
+
     if save_to:
         outfile.close()
     return tree

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -48,18 +48,20 @@ def get_google_url(sclient: Optional[str] = "psy-ab", hl: Optional[str] = "en") 
         sclient = "psy-ab"
     if not hl:
         hl = "en"
-    return f'https://www.google.com/complete/search?sclient={sclient}&hl={hl}&q='
+    params = urllib.parse.urlencode({'sclient': sclient, 'hl': hl, 'q': ''})
+    return f'https://www.google.com/complete/search?{params}'
 
-def get_bing_url(cvid: str = '&cvid=CF23583902D944F1874B7D9E36F452CD') -> str:
+def get_bing_url(cvid: str = 'CF23583902D944F1874B7D9E36F452CD') -> str:
     """Get Bing autocomplete API URL
-    
+
     Args:
         cvid (str): Bing API client ID
-    
+
     Returns:
         str: Base Bing autocomplete API URL
     """
-    return f'http://www.bing.com/AS/Suggestions?&mkt=en-us{cvid}&q='
+    params = urllib.parse.urlencode({'mkt': 'en-us', 'cvid': cvid, 'q': ''})
+    return f'http://www.bing.com/AS/Suggestions?{params}'
 
 def requester(
     qry: str,

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -1,16 +1,17 @@
 """ Recursively retrieve autocomplete suggestions from Google and Bing.
 """
 
-import time
 import json
+import time
 import urllib
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
 import requests
 from numpy import random
-from datetime import datetime, timezone
-from typing import Optional, List, Dict, Union, Any
 
-from . import parsing
-from . import logger
+from . import logger, parsing
+
 log = logger.Logger().start()
 
 def sleep_random(x: float = 0.7, y: float = 1.4) -> None:
@@ -33,13 +34,17 @@ def prepare_qry(qry: str) -> str:
     """
     return urllib.parse.quote_plus(qry)
 
-def get_google_url() -> str:
+def get_google_url(sclient: Optional[str] = "psy-ab", hl: Optional[str] = "en") -> str:
     """Get Google autocomplete API URL
     
     Returns:
         str: Base Google autocomplete API URL
     """
-    return 'https://www.google.com/complete/search?sclient=psy-ab&hl=en&q='
+    if not sclient:
+        sclient = "psy-ab"
+    if not hl:
+        hl = "en"
+    return f'https://www.google.com/complete/search?sclient={sclient}&hl={hl}&q='
 
 def get_bing_url(cvid: str = '&cvid=CF23583902D944F1874B7D9E36F452CD') -> str:
     """Get Bing autocomplete API URL
@@ -57,7 +62,9 @@ def requester(
     source: str = 'bing',
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
-    allow_zip: bool = False
+    allow_zip: bool = False,
+    sclient: Optional[str] = None, 
+    hl: Optional[str] = None
 ) -> Optional[Union[dict, str]]:
     """Requester with logging and specified user agent
     
@@ -78,7 +85,7 @@ def requester(
 
     sesh = sesh if sesh else requests.Session()
 
-    base = get_bing_url() if source == 'bing' else get_google_url() 
+    base = get_bing_url() if source == 'bing' else get_google_url(sclient, hl)
     url = base + prepare_qry(qry)
 
     time.sleep(sleep) if sleep else sleep_random()
@@ -86,7 +93,7 @@ def requester(
     try:
         response = sesh.get(url, timeout=10)
         if source == 'google':
-            return json.loads(response.content)
+            return json.loads(response.content.decode('latin-1'))
         elif source == 'bing':
             return response.content.decode('utf-8')
     except Exception as e:
@@ -98,7 +105,9 @@ def get_suggests(
     source: str = 'bing',
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
-    sesh_headers: Optional[Dict[str, str]] = None
+    sesh_headers: Optional[Dict[str, str]] = None,
+    sclient: Optional[str] = None, 
+    hl: Optional[str] = None
 ) -> Dict[str, Any]:
     """Scrape and parse search engine suggestion data for a query.
     
@@ -119,7 +128,7 @@ def get_suggests(
         'qry': qry,
         'datetime': str(datetime.now(timezone.utc).replace(tzinfo=None)),
         'source': source,
-        'data': requester(qry, source, sesh, sleep)
+        'data': requester(qry, source, sesh, sleep, sclient=sclient, hl=hl)
     }
     
     parser = parsing.parse_bing if source == 'bing' else parsing.parse_google

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -67,8 +67,7 @@ def requester(
     sleep: Optional[float] = None,
     allow_zip: bool = False,
     hl: Optional[str] = None,
-    mkt: Optional[str] = None,
-    sclient: str = "psy-ab"
+    mkt: Optional[str] = None
 ) -> Optional[Union[dict, str]]:
     """Requester with logging and specified user agent
 
@@ -80,7 +79,6 @@ def requester(
         allow_zip (bool): Enable response content unzipping
         hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
         mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
-        sclient (str): Google search client identifier
 
     Returns:
         Optional[Union[dict, str]]: JSON response for Google, HTML string for Bing, None on error
@@ -95,7 +93,7 @@ def requester(
     if source == 'bing':
         base = get_bing_url(mkt or 'en-us')
     else:
-        base = get_google_url(hl or 'en', sclient)
+        base = get_google_url(hl or 'en')
     url = base + prepare_qry(qry)
 
     time.sleep(sleep) if sleep else sleep_random()
@@ -117,8 +115,7 @@ def get_suggests(
     sleep: Optional[float] = None,
     sesh_headers: Optional[Dict[str, str]] = None,
     hl: Optional[str] = None,
-    mkt: Optional[str] = None,
-    sclient: str = "psy-ab"
+    mkt: Optional[str] = None
 ) -> Dict[str, Any]:
     """Scrape and parse search engine suggestion data for a query.
 
@@ -130,7 +127,6 @@ def get_suggests(
         sesh_headers (Optional[Dict[str, str]]): Custom session headers
         hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
         mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
-        sclient (str): Google search client identifier
 
     Returns:
         Dict[str, Any]: Dictionary containing query metadata and suggestions
@@ -143,7 +139,7 @@ def get_suggests(
         'qry': qry,
         'datetime': str(datetime.now(timezone.utc).replace(tzinfo=None)),
         'source': source,
-        'data': requester(qry, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
+        'data': requester(qry, source, sesh, sleep, hl=hl, mkt=mkt)
     }
 
     parser = parsing.parse_bing if source == 'bing' else parsing.parse_google
@@ -161,8 +157,7 @@ def get_suggests_tree(
     crawl_id: Optional[str] = None,
     sleep: Optional[float] = None,
     hl: Optional[str] = None,
-    mkt: Optional[str] = None,
-    sclient: str = "psy-ab"
+    mkt: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """Retrieve autocomplete suggestions tree for a root query
 
@@ -176,7 +171,6 @@ def get_suggests_tree(
         sleep (Optional[float]): Custom sleep duration
         hl (Optional[str]): Google language code (e.g. 'en', 'de', 'fr')
         mkt (Optional[str]): Bing market code (e.g. 'en-us', 'de-de', 'es-es')
-        sclient (str): Google search client identifier
 
     Returns:
         List[Dict[str, Any]]: List of suggestion trees with metadata
@@ -186,7 +180,7 @@ def get_suggests_tree(
         sesh.headers.update(sesh_headers)
 
     depth = 0
-    root_branch = get_suggests(root, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
+    root_branch = get_suggests(root, source, sesh, sleep, hl=hl, mkt=mkt)
     root_branch['depth'] = depth
     root_branch['root'] = root
     root_branch['crawl_id'] = crawl_id
@@ -207,7 +201,7 @@ def get_suggests_tree(
             if suggest_list:
                 for s in suggest_list:
                     if s not in all_suggests: # Don't crawl self-loops or duplicates
-                        branches = get_suggests(s, source, sesh, sleep, hl=hl, mkt=mkt, sclient=sclient)
+                        branches = get_suggests(s, source, sesh, sleep, hl=hl, mkt=mkt)
                         branches['depth'] = depth
                         branches['root'] = root
                         branches['crawl_id'] = crawl_id

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -34,20 +34,16 @@ def prepare_qry(qry: str) -> str:
     """
     return urllib.parse.quote_plus(qry)
 
-def get_google_url(sclient: Optional[str] = "psy-ab", hl: Optional[str] = "en") -> str:
+def get_google_url(hl: str = "en", sclient: str = "psy-ab") -> str:
     """Get Google autocomplete API URL
 
     Args:
-        sclient (Optional[str]): Google search client identifier
-        hl (Optional[str]): Language code for results (e.g. 'en', 'de', 'fr')
+        hl (str): Language code for results (e.g. 'en', 'de', 'fr')
+        sclient (str): Google search client identifier
 
     Returns:
         str: Base Google autocomplete API URL
     """
-    if not sclient:
-        sclient = "psy-ab"
-    if not hl:
-        hl = "en"
     params = urllib.parse.urlencode({'sclient': sclient, 'hl': hl, 'q': ''})
     return f'https://www.google.com/complete/search?{params}'
 
@@ -69,19 +65,19 @@ def requester(
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
     allow_zip: bool = False,
-    sclient: Optional[str] = None, 
-    hl: Optional[str] = None
+    hl: str = "en",
+    sclient: str = "psy-ab"
 ) -> Optional[Union[dict, str]]:
     """Requester with logging and specified user agent
-    
+
     Args:
         qry (str): Search query to submit
         source (str): Search engine to submit query to, either "bing" or "google"
         sesh (Optional[requests.Session]): Pass a custom requests session
         sleep (Optional[float]): Custom sleep duration
         allow_zip (bool): Enable response content unzipping
-        sclient (Optional[str]): Google search client identifier
-        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        sclient (str): Google search client identifier
 
     Returns:
         Optional[Union[dict, str]]: JSON response for Google, HTML string for Bing, None on error
@@ -93,7 +89,7 @@ def requester(
 
     sesh = sesh if sesh else requests.Session()
 
-    base = get_bing_url() if source == 'bing' else get_google_url(sclient, hl)
+    base = get_bing_url() if source == 'bing' else get_google_url(hl, sclient)
     url = base + prepare_qry(qry)
 
     time.sleep(sleep) if sleep else sleep_random()
@@ -114,19 +110,19 @@ def get_suggests(
     sesh: Optional[requests.Session] = None,
     sleep: Optional[float] = None,
     sesh_headers: Optional[Dict[str, str]] = None,
-    sclient: Optional[str] = None, 
-    hl: Optional[str] = None
+    hl: str = "en",
+    sclient: str = "psy-ab"
 ) -> Dict[str, Any]:
     """Scrape and parse search engine suggestion data for a query.
-    
+
     Args:
         qry (str): Query to obtain suggestions for
         source (str): The search engine to submit the query to
         sesh (Optional[requests.Session]): Session for maintaining connection
         sleep (Optional[float]): Custom sleep duration
         sesh_headers (Optional[Dict[str, str]]): Custom session headers
-        sclient (Optional[str]): Google search client identifier
-        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        sclient (str): Google search client identifier
 
     Returns:
         Dict[str, Any]: Dictionary containing query metadata and suggestions
@@ -139,7 +135,7 @@ def get_suggests(
         'qry': qry,
         'datetime': str(datetime.now(timezone.utc).replace(tzinfo=None)),
         'source': source,
-        'data': requester(qry, source, sesh, sleep, sclient=sclient, hl=hl)
+        'data': requester(qry, source, sesh, sleep, hl=hl, sclient=sclient)
     }
     
     parser = parsing.parse_bing if source == 'bing' else parsing.parse_google
@@ -156,11 +152,11 @@ def get_suggests_tree(
     sesh_headers: Optional[Dict[str, str]] = None,
     crawl_id: Optional[str] = None,
     sleep: Optional[float] = None,
-    sclient: Optional[str] = None,
-    hl: Optional[str] = None
+    hl: str = "en",
+    sclient: str = "psy-ab"
 ) -> List[Dict[str, Any]]:
     """Retrieve autocomplete suggestions tree for a root query
-    
+
     Args:
         root (str): Query to obtain a suggestion tree for
         source (str): The search engine to submit the query to
@@ -169,8 +165,8 @@ def get_suggests_tree(
         sesh (Optional[requests.Session]): Session for maintaining connection
         crawl_id (Optional[str]): Unique identifier for the crawl session
         sleep (Optional[float]): Custom sleep duration
-        sclient (Optional[str]): Google search client identifier
-        hl (Optional[str]): Language code for Google results (e.g. 'en', 'de', 'fr')
+        hl (str): Language code for Google results (e.g. 'en', 'de', 'fr')
+        sclient (str): Google search client identifier
 
     Returns:
         List[Dict[str, Any]]: List of suggestion trees with metadata
@@ -180,7 +176,7 @@ def get_suggests_tree(
         sesh.headers.update(sesh_headers)
     
     depth = 0
-    root_branch = get_suggests(root, source, sesh, sleep, sclient=sclient, hl=hl)
+    root_branch = get_suggests(root, source, sesh, sleep, hl=hl, sclient=sclient)
     root_branch['depth'] = depth
     root_branch['root'] = root
     root_branch['crawl_id'] = crawl_id
@@ -201,7 +197,7 @@ def get_suggests_tree(
             if suggest_list:
                 for s in suggest_list:
                     if s not in all_suggests: # Don't crawl self-loops or duplicates
-                        branches = get_suggests(s, source, sesh, sleep, sclient=sclient, hl=hl)
+                        branches = get_suggests(s, source, sesh, sleep, hl=hl, sclient=sclient)
                         branches['depth'] = depth
                         branches['root'] = root
                         branches['crawl_id'] = crawl_id

--- a/suggests/suggests.py
+++ b/suggests/suggests.py
@@ -99,9 +99,9 @@ def requester(
     try:
         response = sesh.get(url, timeout=10)
         if source == 'google':
-            return json.loads(response.content.decode('latin-1'))
+            return json.loads(response.text)
         elif source == 'bing':
-            return response.content.decode('utf-8')
+            return response.text
     except Exception as e:
         log.exception('ERROR SCRAPING: request[%s]', response.status_code)
         return None


### PR DESCRIPTION
## Summary

Cherry-picked language parameter from [jueri/suggests](https://github.com/jueri/suggests) (`44e5b4e`) and extended it with fixes and Bing support.

- Add `hl` param for Google language (e.g. `'es'`, `'de'`) and `mkt` param for Bing market (e.g. `'es-es'`, `'de-de'`)
- Pass language params through `get_suggests`, `requester`, and `get_suggests_tree`
- Use `response.text` for encoding-aware decoding (Google returns `charset=ISO-8859-1`)
- URL-encode all API parameters via `urllib.parse.urlencode`
- Remove `sclient` from public API (hardcoded in `get_google_url`)
- Update README with usage examples for both sources

## Test Results

### Google (Spanish)
```python
>>> s = suggests.get_suggests('los gansos son ', source='google', hl='es')
>>> s['suggests']
['los gansos son territoriales', 'los gansos son monogamos', 'los gansos son patos', 'los gansos son comestibles', 'los gansos son aves']
```

### Bing (Spanish)
```python
>>> s = suggests.get_suggests('los gansos son ', source='bing', mkt='es-es')
>>> s['suggests']
['los gansos son agresivos', 'que son los gansos', 'sonidos de gansos']
```

### get_suggests_tree (German)
```
Tree size: 11
  [0] Gänse sind : ['gänse sind die besseren wachhunde', 'gänse sind zugvögel']
  [1] gänse sind die besseren wachhunde: ['gänse sind die besseren wachhunde', 'gänse wachhund']
  [1] gänse sind zugvögel: ['gänse sind zugvögel', 'welche gänse sind zugvögel']
```